### PR TITLE
Propose change on branch

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,10 +10,6 @@ module.exports = function(eleventyConfig) {
     if (err) throw err;
   });
 
-
-  const gitBranch = process.env.COMPLIANCE_LOGIN;
-  
-
   
   // markdown options
   const options = {

--- a/_content/_data/git.js
+++ b/_content/_data/git.js
@@ -1,0 +1,4 @@
+module.exports = {
+  repo: process.env.REPOSITORY_URL,
+  branch: process.env.BRANCH
+};

--- a/_includes/_edit.njk
+++ b/_includes/_edit.njk
@@ -2,7 +2,7 @@
 	<h1>Help improve this page</h1>
 	<p>You can help improve this page, with updated information, guidance or fixes for typos and errors.</p>
 	<ul>
-		<li><a href="https://github.com/RocketCommunicationsInc/astro-uxds/edit/draft/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
+		<li><a href="https://github.com/RocketCommunicationsInc/astro-uxds/edit/{{ENV.BRANCH}}/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
 		<li><a href="/community/propose-a-change">How to contribute a change</a></li>
 	</ul>
 </footer>

--- a/_includes/_edit.njk
+++ b/_includes/_edit.njk
@@ -2,7 +2,7 @@
 	<h1>Help improve this page</h1>
 	<p>You can help improve this page, with updated information, guidance or fixes for typos and errors.</p>
 	<ul>
-		<li><a href="https://github.com/RocketCommunicationsInc/astro-uxds/edit/{{ git.branch }}/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
+		<li><a href="{{ git.repo if git.repo else 'https://github.com/RocketCommunicationsInc/astro-uxds' }}/edit/{{ git.branch if git.branch else 'master' }}/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
 		<li><a href="/community/propose-a-change">How to contribute a change</a></li>
 	</ul>
 </footer>

--- a/_includes/_edit.njk
+++ b/_includes/_edit.njk
@@ -2,7 +2,7 @@
 	<h1>Help improve this page</h1>
 	<p>You can help improve this page, with updated information, guidance or fixes for typos and errors.</p>
 	<ul>
-		<li><a href="https://github.com/RocketCommunicationsInc/astro-uxds/edit/{{ENV.BRANCH}}/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
+		<li><a href="https://github.com/RocketCommunicationsInc/astro-uxds/edit/{{ git.branch }}/_content{{ page.filePathStem }}.md">Propose a change or fix to this page</a></li>
 		<li><a href="/community/propose-a-change">How to contribute a change</a></li>
 	</ul>
 </footer>


### PR DESCRIPTION
Updated the propose a change feature to support editing the current branch the propose change was made from.

Current behavior was hard coded to the `draft` branch, this caused issues though when `draft` had changed paths or file names leading to a 404.  Also caused confusion about which branch an edit should be merged to.

New behavior, propose change checks out and merges back to the branch the request was made from. E.g., on the published Astro will branch from `master` and default the pull request back to `master` acting as a hotfix.

Proposing a change from `compliance` will branch and merge back to compliance.

Test URL to see if the correct branch is used when proposing a change. https://propose-change-on-branch--astrouxds.netlify.app/components/readme/

**Note** it appears ephemeral PR branches can’t be edited via propose a change. Probably a good idea to avoid PR-ing PRs.