### PR TITLE
Quick Fix for Text Typos

### DIFF
--- a/_content/components/drop-down.md
+++ b/_content/components/drop-down.md
@@ -15,13 +15,11 @@ theme: true
 
 When activated, Drop Down Menus allow users to select a value from a list of values. Once a value is selected, the Drop Down displays the selected value.
 
-Content
-
 ## Rules of Thumb
 
 - Drop Downs should display a list of multiple values.
-- Drop Downs may default to a state that instructs users what to do. For example: “Select Modem” or, a default choice like “Modem X.”
-- When user knows what they’re looking for in advance, consider using a text field with client-side auto-complete functionality instead.
+- Drop Downs may default to a state that instructs users what to do. For example: “Select Modem” or a default choice like “Modem X.”
+- When the user knows what they’re looking for in advance, consider using a text field with client-side auto-complete functionality instead.
 
 ## Examples
 


### PR DESCRIPTION
Not sure if I forgot to submit this PR before or not, but it's still showing differences from draft state.

- Removed unnecessary line with the text "Content"
- Removed unnecessary comma in "or, a default choice like"
- Added the to make sentence flow better in "When user knows what they’re"