### PR TITLE
Astro-506 - Update to bitbucket/github links

### DIFF
--- a/404.md
+++ b/404.md
@@ -11,6 +11,6 @@ Sorry, the page you requested has moved or doesn’t exist.
 
 - [Components Guidelines](/components/readme)
 - [Design Guidelines](/design-guidelines/color)
-- [Astro Sketch/XD Libraries](https://bitbucket.org/rocketcom/astro-design-resources)
+- [Astro Sketch/XD Libraries](https://github.com/RocketCommunicationsInc/astro-design-resources)
 - [Astro Storybook](https://astro-components.netlify.com)
-- [Astro Git Repository](https://bitbucket.org/rocketcom/astro-components)
+- [Astro Git Repository](https://github.com/RocketCommunicationsInc/astro-components)

--- a/_content/404.md
+++ b/_content/404.md
@@ -11,6 +11,6 @@ Sorry, the page you requested has moved or doesn’t exist.
 
 - [Components Guidelines](/components/readme)
 - [Design Guidelines](/design-guidelines/color)
-- [Astro Sketch/XD Libraries](https://bitbucket.org/rocketcom/astro-design-resources)
+- [Astro Sketch/XD Libraries](https://github.com/RocketCommunicationsInc/astro-design-resources)
 - [Astro Storybook](https://astro-components.netlify.com)
-- [Astro Git Repository](https://bitbucket.org/rocketcom/astro-components)
+- [Astro Git Repository](https://github.com/RocketCommunicationsInc/astro-components)

--- a/_content/components/_readme.md
+++ b/_content/components/_readme.md
@@ -15,9 +15,9 @@ There are two ways to use the Astro elements in your applications. You may simpl
 
 ## Getting Started with HTML & CSS
 
-[Additional Documentation/Git Repository](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static)
+[Additional Documentation/Git Repository](https://github.com/RocketCommunicationsInc/astro-components)
 
-Download and unzip the [Astro UI](https://bitbucket.org/rocketcom/astro-styles/get/master.zip) Library and copy the ASTRO.css file and img directory to your project folder. In the head of all .html documents, add a link element with an href attribute to the relative location of astro.css or astro.min.css. Copy the /icons and /fonts directory to the root of your project. Note: astro.css and astro.min.css assume they are located in a sibling directory to /icons and /fonts.
+Download the [Astro UI](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static) Library and copy the ASTRO.css file and img directory to your project folder. In the head of all .html documents, add a link element with an href attribute to the relative location of astro.css or astro.min.css. Copy the /icons and /fonts directory to the root of your project. Note: astro.css and astro.min.css assume they are located in a sibling directory to /icons and /fonts.
 
 Example:
 

--- a/_content/components/_readme.md
+++ b/_content/components/_readme.md
@@ -15,7 +15,7 @@ There are two ways to use the Astro elements in your applications. You may simpl
 
 ## Getting Started with HTML & CSS
 
-[Additional Documentation/Git Repository](https://bitbucket.org/rocketcom/astro-styles/src/master/)
+[Additional Documentation/Git Repository](https://github.com/RocketCommunicationsInc/astro-components/tree/master/static)
 
 Download and unzip the [Astro UI](https://bitbucket.org/rocketcom/astro-styles/get/master.zip) Library and copy the ASTRO.css file and img directory to your project folder. In the head of all .html documents, add a link element with an href attribute to the relative location of astro.css or astro.min.css. Copy the /icons and /fonts directory to the root of your project. Note: astro.css and astro.min.css assume they are located in a sibling directory to /icons and /fonts.
 

--- a/_content/components/button.md
+++ b/_content/components/button.md
@@ -4,10 +4,10 @@ path: /components/button
 date: Last Modified
 layout: components.template.njk
 title: Button
-demo: https://rocketcom.bitbucket.io/html-demos/button.html
+demo: https://astro-components.netlify.app/iframe.html?id=components-buttons--all-button-variants&viewMode=story
 storybook: components-buttons--standard-button
 git: rux-button
-height: 210px
+height: 260px
 theme: true
 ---
 

--- a/_content/components/input-field.md
+++ b/_content/components/input-field.md
@@ -4,7 +4,7 @@ path: /components/input-field
 date: Last Modified
 layout: components.template.njk
 title: Input Field
-demo: https://rocketcom.bitbucket.io/html-demos/input.html
+demo: https://astro-components.netlify.app/iframe.html?id=components-form-elements--input-fields&viewMode=story
 storybook: components-form-elements--input-fields
 git:
 height: 310px

--- a/_content/components/notification-banner.md
+++ b/_content/components/notification-banner.md
@@ -4,7 +4,7 @@ path: /components/notification-banner
 date: Last Modified
 layout: components.template.njk
 title: Notification Banner
-demo: https://rocketcom.bitbucket.io/html-demos/notification.html
+demo: https://astro-components.netlify.app/iframe.html?id=components-notification--all-notification-banners&viewMode=story
 storybook: components-notification--all-notification-banners
 git: rux-notification
 height: 440px

--- a/_content/components/pop-up.md
+++ b/_content/components/pop-up.md
@@ -4,7 +4,7 @@ path: /components/pop-up
 date: Last Modified
 layout: components.template.njk
 title: Pop Up
-demo: https://rocketcom.bitbucket.io/html-demos/pop-up.html
+demo: https://astro-components.netlify.app/iframe.html?id=components-pop-up-menu--pop-up-menu&viewMode=story
 storybook: components-pop-up-menu--pop-up-menu
 git: rux-pop-up-menu
 height: 450px

--- a/_content/components/progress.md
+++ b/_content/components/progress.md
@@ -4,7 +4,7 @@ path: /components/progress
 date: Last Modified
 layout: components.template.njk
 title: Progress
-demo: https://rocketcom.bitbucket.io/html-demos/progress.html
+demo: https://astro-components.netlify.app/iframe.html?id=components-progress--determinate-progress&viewMode=story
 storybook: components-progress
 git: rux-progress
 height: 160px

--- a/_content/getting-started.md
+++ b/_content/getting-started.md
@@ -21,6 +21,14 @@ Before reading any further, we recommend you take a look at a live [Astro sample
 
 ## What's New
 
+### Astro 5.0
+- [Astro 5 XD Dark Library](https://github.com/RocketCommunicationsInc/astro-design-resources/raw/master/Adobe%20XD/Astro%205%20Dark%20Library.xd)
+- [Astro 5 XD Wireframe Library](https://github.com/RocketCommunicationsInc/astro-design-resources/raw/master/Adobe%20XD/Astro%205%20Wireframe%20Library.xd)
+- [Astro 5 Sketch Dark Library](https://github.com/RocketCommunicationsInc/astro-design-resources/raw/master/Sketch/Astro%20Dark%20Library.sketch)
+- [Astro 5 Sketch Dark Stickersheet](https://github.com/RocketCommunicationsInc/astro-design-resources/raw/master/Sketch/Astro%20Dark%20Stickersheet.sketch)
+- [Astro 5 Sketch Wireframe Library](https://github.com/RocketCommunicationsInc/astro-design-resources/raw/master/Sketch/Astro%20Wireframe%20Library.sketch)
+- [Astro 5 Sketch Stickersheet](https://github.com/RocketCommunicationsInc/astro-design-resources/raw/master/Sketch/Astro%20Wireframe%20Stickersheet.sketch)
+
 ### Astro 4.5
 
 - [EGS Design Compliance](/design-guidelines/compliance)


### PR DESCRIPTION
### https://rocketcom.atlassian.net/browse/ASTRO-506

Task Description:

- Updated legacy links from bitbucket repos to github for AstroUXDS
- Some Legacy bitbucket references have been left in place in a few instances.
     1) TT&C/ GRM dashboard links have been left in place. 
     2) Previous link versions of Astro Design resources have been left in place. 
     3) Any component demo links utilizing bitbucket do not have appropriate demos on https://astro-components.netlify.app/