### PR TITLE
Astro-570 - Select menu link update

### DIFF
--- a/_content/components/select.md
+++ b/_content/components/select.md
@@ -6,6 +6,8 @@ layout: components.template.njk
 title: Select Menu
 demo: https://astro-components.netlify.com/iframe.html?id=components-form-elements--select-menu
 storybook: components-form-elements--select-menu
+git:
+css: select-menu-README.md
 height: 130px
 theme: true
 ---

--- a/_includes/components.template.njk
+++ b/_includes/components.template.njk
@@ -19,8 +19,13 @@
 						Storybook
 					</a>
 				{% endif %}
+
 				{% if git %}
 					<a class="sample-links__github" href="https://github.com/RocketCommunicationsInc/astro-components/tree/master/src/components/{{git}}">Github</a>
+				{% endif %}
+				
+				{% if css %}
+					<a class="sample-links__github" href="https://github.com/RocketCommunicationsInc/astro-components/blob/master/src/css/documentation//{{css}}">Github</a>
 				{% endif %}
 			</div>
 		</div>


### PR DESCRIPTION
### https://rocketcom.atlassian.net/browse/ASTRO-570

**Changes:**

- Correction/inclusion of github link for select/drop-down menu component/styling



@dmcalester Can we please confirm that the updated link is correct for the dropdown documentation. Usually github links are directed to a component dir, as this is not a component and is a css class styling convention, I used the link to that css readme doc. 