### PR TITLE
HOTFIX: update height on input and button components demo frames

### DIFF
--- a/_content/components/accordion.md
+++ b/_content/components/accordion.md
@@ -5,11 +5,13 @@ tags: components
 path: /components/accordion
 layout: components.template.njk
 theme: false
-demo: components-accordion--accordion
+demo: components--accordion
 height: 210px
-storybook: components-accordion--accordion
+storybook: components--accordion
+scrolling: yes
 git: rux-accordion
 ---
+
 # Accordion
 
 ::: caution
@@ -20,8 +22,8 @@ An Accordion is a device which presents a hierarchical set of items in which onl
 
 ## Rules of Thumb
 
-* Give titles to Accordions if content is not obvious to users.
-* Titles should use sentence case capitalization.
+- Give titles to Accordions if content is not obvious to users.
+- Titles should use sentence case capitalization.
   ::: note
   Accordions are not commonly used for direct action or data manipulation. Use Accordions for navigation within a master-detail navigational pattern.
   :::
@@ -36,13 +38,8 @@ Clicking on an item in an Accordion selects and expands that item. If there are 
 
 ![Chapter 1 is selected and its children are displayed.](/img/components/accordion-2.png "Do: Item 1 is selected and its children are displayed.")
 
-
-
 ![If a child item of the current selection is selected, that entire branch remains displayed.](/img/components/accordion-3.png "If a child item of the current selection is selected, that entire branch remains displayed.")
 
-
-
 ![If a different branch is selected, for example, by clicking on a different top level item, the current branch automatically closes and the new branch opens.](/img/components/accordion-4.png "If a different branch is selected, for example, by clicking on a different top level item, the current branch automatically closes and the new branch opens.")
-
 
 :::

--- a/_content/components/button.md
+++ b/_content/components/button.md
@@ -8,6 +8,7 @@ demo: components-buttons--all-button-variants
 storybook: components-buttons--standard-button
 git: rux-button
 height: 260px
+scrolling: true
 theme: true
 ---
 

--- a/_content/components/button.md
+++ b/_content/components/button.md
@@ -7,7 +7,7 @@ title: Button
 demo: components-buttons--all-button-variants
 storybook: components-buttons--standard-button
 git: rux-button
-height: 260px
+height: 975px
 theme: true
 ---
 

--- a/_content/components/button.md
+++ b/_content/components/button.md
@@ -8,7 +8,6 @@ demo: components-buttons--all-button-variants
 storybook: components-buttons--standard-button
 git: rux-button
 height: 260px
-overflow: scroll
 theme: true
 ---
 

--- a/_content/components/button.md
+++ b/_content/components/button.md
@@ -7,7 +7,8 @@ title: Button
 demo: components-buttons--all-button-variants
 storybook: components-buttons--standard-button
 git: rux-button
-height: 975px
+height: 260px
+overflow: scroll
 theme: true
 ---
 

--- a/_content/components/button.md
+++ b/_content/components/button.md
@@ -8,7 +8,7 @@ demo: components-buttons--all-button-variants
 storybook: components-buttons--standard-button
 git: rux-button
 height: 260px
-scrolling: true
+scrolling: yes
 theme: true
 ---
 

--- a/_content/components/classification-markings.md
+++ b/_content/components/classification-markings.md
@@ -19,15 +19,16 @@ All classification and control markings on this page are for illustration purpos
 :::
 
 ### Official Requirements
+
 This page lists general guidance and components for marking practices. For the most up-to-date policies, use the following resource links which should bxe considered the prime authorities for CNSI (Classified National Security Information) and CUI (Controlled Unclassified Information). In addition to these requirements, each government agency may have their own rules to use with those listed below.
 
-
 ### Classified National Security Information
+
 - [ISOO Training Aids](https://www.archives.gov/isoo/training/training-aids): Latest standards for CNSI from the ISOO (Information Security Oversight Office)
 - [ISOO Blog](https://isoo-overview.blogs.archives.gov/): Latest updates for ISOO topics including CNSI and CUI
 
-
 ### Controlled Unclassified Information
+
 - [CUI Registry](https://www.archives.gov/cui): Latest standards for CUI from the NARA
 - [CUI Blog](https://isoo.blogs.archives.gov/): Latest updates for CUI including previews of upcoming policy changes
 
@@ -37,14 +38,14 @@ The guidance on this page is focused on the use of, and rules for, classificatio
 
 ### Banner Examples
 
-| |State                                                    | Hex Value   | RGB Value | Custom Property Name | Font Color  |
-| ---| -------------------------------------------------------- | ----------- | -------------- | ------------------------------ | -------------- |
-| ![Marking Unclassified Swatch](/img/swatches/marking__unclassified.svg)| Unclassified                                       | `#007a33`   | `0, 122, 51`   | `--classificationUnclassified` | `white` |
-| ![Marking Top Secret//SCI Swatch](/img/swatches/marking__top-secret-sci.svg)| Top Secret//SCI                                          | `#fce83a`   | `252, 232, 58` | `--classificationTopSecretSCI` | `black` |
-|![Marking Top Secret Swatch](/img/swatches/marking__top-secret.svg) | Top Secret                                               | `#ff8c00`   | `255, 140, 0`  | `--classificationTopSecret`    | `black` |
-|![Marking Secret Swatch](/img/swatches/marking__secret.svg) | Secret                                                   | `#c8102e`   | `200, 16, 46`  | `--classificationSecret`       | `white` |
-| ![Marking Controlled Swatch](/img/swatches/marking__controlled.svg)| Controlled (CUI)                                         | `#502b85`   | `80, 43, 133`  | `--classificationControlled`   | `white` |
-|![Marking Confidential Swatch](/img/swatches/marking__confidential.svg) | Confidential                                             | `#0033a0`   | `0, 51, 160`   | `--classificationConfidential` | `white` |
+|                                                                              | State            | Hex Value | RGB Value      | Custom Property Name           | Font Color |
+| ---------------------------------------------------------------------------- | ---------------- | --------- | -------------- | ------------------------------ | ---------- |
+| ![Marking Unclassified Swatch](/img/swatches/marking__unclassified.svg)      | Unclassified     | `#007a33` | `0, 122, 51`   | `--classificationUnclassified` | `white`    |
+| ![Marking Top Secret//SCI Swatch](/img/swatches/marking__top-secret-sci.svg) | Top Secret//SCI  | `#fce83a` | `252, 232, 58` | `--classificationTopSecretSCI` | `black`    |
+| ![Marking Top Secret Swatch](/img/swatches/marking__top-secret.svg)          | Top Secret       | `#ff8c00` | `255, 140, 0`  | `--classificationTopSecret`    | `black`    |
+| ![Marking Secret Swatch](/img/swatches/marking__secret.svg)                  | Secret           | `#c8102e` | `200, 16, 46`  | `--classificationSecret`       | `white`    |
+| ![Marking Controlled Swatch](/img/swatches/marking__controlled.svg)          | Controlled (CUI) | `#502b85` | `80, 43, 133`  | `--classificationControlled`   | `white`    |
+| ![Marking Confidential Swatch](/img/swatches/marking__confidential.svg)      | Confidential     | `#0033a0` | `0, 51, 160`   | `--classificationConfidential` | `white`    |
 
 ### Overall Marking Background Information
 
@@ -78,7 +79,6 @@ Astro banner component colors match what government users are familiar with in p
 
 ![Don't: Deviate from the defined background colors](/img/components/overall-marking-dont-3.png "Don't: Deviate from the defined background colors")
 
-
 :::
 
 ## Portion Marking
@@ -98,13 +98,15 @@ Current policies require portion marking throughout a document, but, in practice
 There are few exceptions to portion marking requirements, but the ISOO does acknowledge that different types of documents such as “dynamic documents,” a category that many applications or databases fall under, may have difficulty with these requirements. If a document is not portion marked fully and the classification/control level is higher than CUI, the responsible agency for the application may need to obtain a waiver from the ISOO and will need to indicate on the document that it cannot be used as a derivative source document.
 
 ### Portion Marking Text
+
 Portion markings should be bold, all capital letters and abbreviated within parentheses like (CUI//SP-EXPT) or within a tag as seen in the components pictured above. They can also be spelled out in full, if needed, however this method should be avoided for longer text strings. Note that control markings such as SCI, SAP, AEA, CUI, or dissemination are also required in portion markings if they are relevant to that portion.
 
-
 ### Portion Marking Placement
+
 Portion markings should be placed at the top or top-left of the classified or controlled portion. Astro recommends using the tag version of portion marking if the markings are at a higher section or card level. For more in-line text portions or portions lower in the visual hierarchy of the User Interface, use the text-only version.
 
 ### Portion Marking Colors
+
 The colors used in the tag components are the same as those in the overall banner markings for easy recognition.
 
 ## Examples
@@ -123,7 +125,6 @@ The colors used in the tag components are the same as those in the overall banne
 
 ![Don't: Clutter the interface with colored tags on every line](/img/components/portion-marking-dont-3.png "Don't: Clutter the interface with colored tags on every line")
 
-
 :::
 
 ## Authority Block
@@ -132,25 +133,27 @@ The colors used in the tag components are the same as those in the overall banne
 
 Whenever classified or controlled information is present, use an Authority Block, to trace the source of the designation and any necessary clarifications about declassification dates or classification reasons. The authority block is typically in the bottom left of a document page, but can be placed elsewhere according to layout needs. Similarly, if necessary in the layout, the authority information for electronic material may appear as a single line of text instead of the typical three-line approach. Note that there is a slightly different structure for CUI, originally classified documents, and documents with a classification derived from another document. Authority blocks are most often displayed as lines of text and do not currently require a component to satisfy this marking requirement. To learn more about this element, go to our [Additional Resources](#additional-resources).
 
-| **Do**                     |
-|------------------------ |
-| Show the source of classified or controlled information on a page with relevant contact information.|
+| **Do**                                                                                                           |
+| ---------------------------------------------------------------------------------------------------------------- |
+| Show the source of classified or controlled information on a page with relevant contact information.             |
 | Clarify if the classified information is originally classified or derivatively classified from another document. |
 
 ## Additional Resources
 
 ### Classified National Security Information
+
 - [ISOO Training Aids](https://www.archives.gov/isoo/training/training-aids): Latest standards for CNSI from the ISOO
-	- [32 CFR Parts 2001 and 2003 - Classified National Security Information; Final Rule (28 June 2010)](https://www.archives.gov/files/isoo/policy-documents/isoo-implementing-directive.pdf)
-	- [Marking Classified National Security Information, Rev. 4 (January 2018)](https://www.archives.gov/files/isoo/notices/marking-booklet-revision.pdf)
+  - [32 CFR Parts 2001 and 2003 - Classified National Security Information; Final Rule (28 June 2010)](https://www.archives.gov/files/isoo/policy-documents/isoo-implementing-directive.pdf)
+  - [Marking Classified National Security Information, Rev. 4 (January 2018)](https://www.archives.gov/files/isoo/notices/marking-booklet-revision.pdf)
 - [ISOO Marking FAQs](https://www.archives.gov/isoo/faqs#50x-and-75x-requirements)
 - [ISOO Blog: Latest updates for ISOO topics including CNSI and CUI](https://isoo-overview.blogs.archives.gov/)
 - [CDSE: Information Security](https://www.cdse.edu/catalog/information-security.html)
 - [At Ease Computing, Inc. Online Store - U.S. Government Security Labels (SF)](http://www.at-ease-inc.com/sflabel.php)
 
 ### Controlled Unclassified Information
+
 - [CUI Registry](https://www.archives.gov/cui): Latest standards for CUI from the NARA
-	- [32 CFR Part 2002 - Controlled Unclassified Information (CUI) (7-1-2018)](https://www.govinfo.gov/content/pkg/CFR-2018-title32-vol6/pdf/CFR-2018-title32-vol6-part2002.pdf)
-	- [CUI Marking Handbook V1.1 (6 December 2016)](https://www.archives.gov/files/cui/documents/20161206-cui-marking-handbook-v1-1-20190524.pdf)
-	- [CUI Coversheet and Labels: SF 901, 902, 903](https://isoo.blogs.archives.gov/2019/02/12/coversheets/)
+  - [32 CFR Part 2002 - Controlled Unclassified Information (CUI) (7-1-2018)](https://www.govinfo.gov/content/pkg/CFR-2018-title32-vol6/pdf/CFR-2018-title32-vol6-part2002.pdf)
+  - [CUI Marking Handbook V1.1 (6 December 2016)](https://www.archives.gov/files/cui/documents/20161206-cui-marking-handbook-v1-1-20190524.pdf)
+  - [CUI Coversheet and Labels: SF 901, 902, 903](https://isoo.blogs.archives.gov/2019/02/12/coversheets/)
 - [CUI Blog](https://isoo.blogs.archives.gov/): Latest updates for CUI including previews of upcoming policy changes

--- a/_content/components/input-field.md
+++ b/_content/components/input-field.md
@@ -8,7 +8,7 @@ demo: components-form-elements--input-fields
 storybook: components-form-elements--input-fields
 git:
 height: 400px
-scrolling: true
+scrolling: yes
 theme: true
 ---
 

--- a/_content/components/input-field.md
+++ b/_content/components/input-field.md
@@ -7,15 +7,13 @@ title: Input Field
 demo: components-form-elements--input-fields
 storybook: components-form-elements--input-fields
 git:
-height: 310px
+height: 1150px
 theme: true
 ---
 
 # Input Field
 
-
 Input Fields allow users to enter freeform text. Variations on this field often provide specific data entry formats such as masked data (e.g. passwords or phone numbers), date and time, and numeric data entry.
-
 
 ## Rules of Thumb
 
@@ -32,13 +30,14 @@ Input Fields allow users to enter freeform text. Variations on this field often 
 - When appropriate, use input masking to automatically format a user's entry. E.g., when entering a phone number, apply a consistent, recognizable format like (XXX) XXX-XXXX or another similar format.
 
 ## Appearance and Behavior
+
 An Input Field consists of a descriptive, concise label paired with an entry field. Optionally, inputs may include help text, left-aligned beneath the input, to assist the user in understanding what kind of content is accepted by the input. Inputs displayed in a form may also be paired with a visual indicator of a required, or optional state. Disabled inputs are displayed with a different opacity and cannot be interacted with by the user.
 
 Standard states for Input Fields include Active (the default, interactive state for a text input), Hover (the user has paused over an active or focussed input), Focus (the field is selected and ready for data entry), Disabled (the field is not interactive, and its content is not sent when the form is submitted), and Read-only.
 
 An Input Field is enabled if it is eligible for interaction and focused if it is the current target for keystrokes.
 
-An Input Field can be configured for required input, limited data ranges, or specific data formats. To learn more about adding Help Text or Validation to Input Fields, see the [Forms and Validation](/patterns/forms-and-validation) guidance. 
+An Input Field can be configured for required input, limited data ranges, or specific data formats. To learn more about adding Help Text or Validation to Input Fields, see the [Forms and Validation](/patterns/forms-and-validation) guidance.
 
 Input Fields have a smaller variant which may be beneficial in layouts where space is at a premium.
 

--- a/_content/components/input-field.md
+++ b/_content/components/input-field.md
@@ -7,7 +7,8 @@ title: Input Field
 demo: components-form-elements--input-fields
 storybook: components-form-elements--input-fields
 git:
-height: 1150px
+height: 400px
+overflow: scroll
 theme: true
 ---
 

--- a/_content/components/input-field.md
+++ b/_content/components/input-field.md
@@ -8,6 +8,7 @@ demo: components-form-elements--input-fields
 storybook: components-form-elements--input-fields
 git:
 height: 400px
+scrolling: true
 theme: true
 ---
 

--- a/_content/components/input-field.md
+++ b/_content/components/input-field.md
@@ -8,7 +8,6 @@ demo: components-form-elements--input-fields
 storybook: components-form-elements--input-fields
 git:
 height: 400px
-overflow: scroll
 theme: true
 ---
 

--- a/_content/components/select.md
+++ b/_content/components/select.md
@@ -9,6 +9,7 @@ storybook: components-form-elements--select-menu
 git:
 css: select-menu-README.md
 height: 130px
+scrolling: yes
 theme: true
 ---
 
@@ -33,7 +34,6 @@ When activated, Select Menus allow users to select a value from a list. Once a v
 The Select component consists of an input field containing a downward facing caret icon. Clicking on the caret expands a list of items (below, or above if there is no room below due to the position of the component on screen) related to the input field. Once an item in the list is selected, the selection is populated in the input field.
 
 To learn more about adding Help Text or Validation to Select Menus, see the [Forms and Validation](/patterns/forms-and-validation) guidance.
-
 
 ## Examples
 

--- a/_content/components/tree.md
+++ b/_content/components/tree.md
@@ -8,6 +8,7 @@ demo: components-tree--tree
 storybook: components-tree--tree
 git: rux-tree
 height: 480px
+scrolling: yes
 theme: true
 ---
 

--- a/_includes/components.template.njk
+++ b/_includes/components.template.njk
@@ -14,9 +14,9 @@
 
 
 			{% if legacyDemo %}
-				<iframe id="live-sample" class="live-sample" scrolling="auto" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+				<iframe id="live-sample" class="live-sample" scrolling="no" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
 			{% else %}
-				{% if title === 'Button' or title === 'Input Field' %}
+				{% if scrolling %}
 					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
 				{% elif meta.branch and meta.branch === 'draft' %}
 					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>

--- a/_includes/components.template.njk
+++ b/_includes/components.template.njk
@@ -14,13 +14,13 @@
 
 
 			{% if legacyDemo %}
-				<iframe id="live-sample" class="live-sample" scrolling="no" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+				<iframe id="live-sample" class="live-sample" scrolling="yes" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: {{overflow}};"></iframe>
 			{% else %}
 
 				{% if meta.branch and meta.branch === 'draft' %}
-					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: {{overflow}};"></iframe>
 				{% else %}
-					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: {{overflow}};"></iframe>
 				{% endif %}
 			{% endif %}
 

--- a/_includes/components.template.njk
+++ b/_includes/components.template.njk
@@ -14,13 +14,14 @@
 
 
 			{% if legacyDemo %}
-				<iframe id="live-sample" class="live-sample" scrolling="yes" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: {{overflow}};"></iframe>
+				<iframe id="live-sample" class="live-sample" scrolling="auto" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
 			{% else %}
-
-				{% if meta.branch and meta.branch === 'draft' %}
-					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: {{overflow}};"></iframe>
+				{% if title === 'Button' or title === 'Input Field' %}
+					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+				{% elif meta.branch and meta.branch === 'draft' %}
+					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
 				{% else %}
-					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: {{overflow}};"></iframe>
+					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
 				{% endif %}
 			{% endif %}
 

--- a/_includes/components.template.njk
+++ b/_includes/components.template.njk
@@ -9,20 +9,22 @@
 	<h1>{{ title }}</h1>
 	
 	{% if demo %}
-
+		{% if scrolling !== 'yes' %}
+			{% set scrolling = 'no' %}
+		{% endif %}
 		<div class="demo-container">
 
 
 			{% if legacyDemo %}
-				<iframe id="live-sample" class="live-sample" scrolling="no" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+				<iframe id="live-sample" class="live-sample" scrolling="{{ scrolling }}" src="{{ demo }}" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
 			{% else %}
-				{% if scrolling %}
-					<iframe id="live-sample" class="live-sample" scrolling="yes" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
-				{% elif meta.branch and meta.branch === 'draft' %}
-					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
-				{% else %}
-					<iframe id="live-sample" class="live-sample" scrolling="no" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
-				{% endif %}
+
+					{% if meta.branch and meta.branch === 'draft' %}
+						<iframe id="live-sample" class="live-sample" scrolling="{{ scrolling }}" src="https://next--astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+					{% else %}
+						<iframe id="live-sample" class="live-sample" scrolling="{{ scrolling }}" src="https://astro-components.netlify.app/iframe.html?id={{ demo }}&viewMode=story" style="width: 100%; height: {{height}}; overflow: hidden;"></iframe>
+					{% endif %}
+					
 			{% endif %}
 
 			<div class="demo-container__sample-links">


### PR DESCRIPTION
Jira Links:
 - https://rocketcom.atlassian.net/browse/ASTRO-1805 --> button
 - https://rocketcom.atlassian.net/browse/ASTRO-1806 --> input

This change makes it so all button and input variants are visible in their corresponding iframe demo's.

Another possible approach is to enable overflow: scroll on these, if we decide that the demo frames are too big.