### PR TITLE
Fixed "Guage" typos on Data Viz page

### DIFF
--- a/_content/patterns/data-visualization.md
+++ b/_content/patterns/data-visualization.md
@@ -87,9 +87,9 @@ This chart type excels at showing changes to total, but seeing change in compone
 
 :::col
 
-#### Fill Guage
+#### Fill Gauge
 
-![Fill Guage](/img/patterns/data-viz-fill-gauge.png)
+![Fill Gauge](/img/patterns/data-viz-fill-gauge.png)
 A circular shape that represents a percentage value of a whole. May also be depicted as a dial.
 
 :::


### PR DESCRIPTION
Fixes two Guage typos back to Gauge on the Data Viz page's documentation.

Jira: https://rocketcom.atlassian.net/browse/ASTRO-1857